### PR TITLE
feat: add custom color theme support

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,674 +1,429 @@
-lockfileVersion: '6.0'
+lockfileVersion: '9.0'
 
 settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-dependencies:
-  '@types/chrome':
-    specifier: ^0.0.269
-    version: 0.0.269
-  core-js:
-    specifier: ^3.37.1
-    version: 3.37.1
-  date-fns:
-    specifier: 3.6.0
-    version: 3.6.0
-  pinia:
-    specifier: ^2.2.0
-    version: 2.2.0(typescript@5.5.4)(vue@3.4.35)
-  vue:
-    specifier: ^3.4.35
-    version: 3.4.35(typescript@5.5.4)
+importers:
 
-devDependencies:
-  '@types/node':
-    specifier: ^22.0.2
-    version: 22.0.2
-  '@vitejs/plugin-vue':
-    specifier: ^5.1.2
-    version: 5.1.2(vite@5.3.5)(vue@3.4.35)
-  prettier:
-    specifier: ^3.3.3
-    version: 3.3.3
-  typescript:
-    specifier: ^5.5.4
-    version: 5.5.4
-  vite:
-    specifier: ^5.3.5
-    version: 5.3.5(@types/node@22.0.2)
-  vue-tsc:
-    specifier: ^2.0.29
-    version: 2.0.29(typescript@5.5.4)
+  .:
+    dependencies:
+      '@types/chrome':
+        specifier: ^0.0.269
+        version: 0.0.269
+      core-js:
+        specifier: ^3.37.1
+        version: 3.37.1
+      date-fns:
+        specifier: 3.6.0
+        version: 3.6.0
+      pinia:
+        specifier: ^2.2.0
+        version: 2.2.0(typescript@5.5.4)(vue@3.4.35)
+      vue:
+        specifier: ^3.4.35
+        version: 3.4.35(typescript@5.5.4)
+    devDependencies:
+      '@types/node':
+        specifier: ^22.0.2
+        version: 22.0.2
+      '@vitejs/plugin-vue':
+        specifier: ^5.1.2
+        version: 5.1.2(vite@5.3.5)(vue@3.4.35)
+      prettier:
+        specifier: ^3.3.3
+        version: 3.3.3
+      typescript:
+        specifier: ^5.5.4
+        version: 5.5.4
+      vite:
+        specifier: ^5.3.5
+        version: 5.3.5(@types/node@22.0.2)
+      vue-tsc:
+        specifier: ^2.0.29
+        version: 2.0.29(typescript@5.5.4)
 
 packages:
 
-  /@babel/helper-string-parser@7.24.8:
+  '@babel/helper-string-parser@7.24.8':
     resolution: {integrity: sha512-pO9KhhRcuUyGnJWwyEgnRJTSIZHiT+vMD0kPeD+so0l7mxkMT19g3pjY9GTnHySck/hDzq+dtW/4VgnMkippsQ==}
     engines: {node: '>=6.9.0'}
 
-  /@babel/helper-validator-identifier@7.24.7:
+  '@babel/helper-validator-identifier@7.24.7':
     resolution: {integrity: sha512-rR+PBcQ1SMQDDyF6X0wxtG8QyLCgUB0eRAGguqRLfkCA87l7yAP7ehq8SNj96OOGTO8OBV70KhuFYcIkHXOg0w==}
     engines: {node: '>=6.9.0'}
 
-  /@babel/parser@7.25.3:
+  '@babel/parser@7.25.3':
     resolution: {integrity: sha512-iLTJKDbJ4hMvFPgQwwsVoxtHyWpKKPBrxkANrSYewDPaPpT5py5yeVkgPIJ7XYXhndxJpaA3PyALSXQ7u8e/Dw==}
     engines: {node: '>=6.0.0'}
     hasBin: true
-    dependencies:
-      '@babel/types': 7.25.2
 
-  /@babel/types@7.25.2:
+  '@babel/types@7.25.2':
     resolution: {integrity: sha512-YTnYtra7W9e6/oAZEHj0bJehPRUlLH9/fbpT5LfB0NhQXyALCRkRs3zH9v07IYhkgpqX6Z78FnuccZr/l4Fs4Q==}
     engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/helper-string-parser': 7.24.8
-      '@babel/helper-validator-identifier': 7.24.7
-      to-fast-properties: 2.0.0
 
-  /@esbuild/aix-ppc64@0.21.5:
+  '@esbuild/aix-ppc64@0.21.5':
     resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
     engines: {node: '>=12'}
     cpu: [ppc64]
     os: [aix]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@esbuild/android-arm64@0.21.5:
+  '@esbuild/android-arm64@0.21.5':
     resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [android]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@esbuild/android-arm@0.21.5:
+  '@esbuild/android-arm@0.21.5':
     resolution: {integrity: sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==}
     engines: {node: '>=12'}
     cpu: [arm]
     os: [android]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@esbuild/android-x64@0.21.5:
+  '@esbuild/android-x64@0.21.5':
     resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [android]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@esbuild/darwin-arm64@0.21.5:
+  '@esbuild/darwin-arm64@0.21.5':
     resolution: {integrity: sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [darwin]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@esbuild/darwin-x64@0.21.5:
+  '@esbuild/darwin-x64@0.21.5':
     resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [darwin]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@esbuild/freebsd-arm64@0.21.5:
+  '@esbuild/freebsd-arm64@0.21.5':
     resolution: {integrity: sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [freebsd]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@esbuild/freebsd-x64@0.21.5:
+  '@esbuild/freebsd-x64@0.21.5':
     resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [freebsd]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@esbuild/linux-arm64@0.21.5:
+  '@esbuild/linux-arm64@0.21.5':
     resolution: {integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@esbuild/linux-arm@0.21.5:
+  '@esbuild/linux-arm@0.21.5':
     resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
     engines: {node: '>=12'}
     cpu: [arm]
     os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@esbuild/linux-ia32@0.21.5:
+  '@esbuild/linux-ia32@0.21.5':
     resolution: {integrity: sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==}
     engines: {node: '>=12'}
     cpu: [ia32]
     os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@esbuild/linux-loong64@0.21.5:
+  '@esbuild/linux-loong64@0.21.5':
     resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
     engines: {node: '>=12'}
     cpu: [loong64]
     os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@esbuild/linux-mips64el@0.21.5:
+  '@esbuild/linux-mips64el@0.21.5':
     resolution: {integrity: sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==}
     engines: {node: '>=12'}
     cpu: [mips64el]
     os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@esbuild/linux-ppc64@0.21.5:
+  '@esbuild/linux-ppc64@0.21.5':
     resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
     engines: {node: '>=12'}
     cpu: [ppc64]
     os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@esbuild/linux-riscv64@0.21.5:
+  '@esbuild/linux-riscv64@0.21.5':
     resolution: {integrity: sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==}
     engines: {node: '>=12'}
     cpu: [riscv64]
     os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@esbuild/linux-s390x@0.21.5:
+  '@esbuild/linux-s390x@0.21.5':
     resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
     engines: {node: '>=12'}
     cpu: [s390x]
     os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@esbuild/linux-x64@0.21.5:
+  '@esbuild/linux-x64@0.21.5':
     resolution: {integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@esbuild/netbsd-x64@0.21.5:
+  '@esbuild/netbsd-x64@0.21.5':
     resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [netbsd]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@esbuild/openbsd-x64@0.21.5:
+  '@esbuild/openbsd-x64@0.21.5':
     resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [openbsd]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@esbuild/sunos-x64@0.21.5:
+  '@esbuild/sunos-x64@0.21.5':
     resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [sunos]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@esbuild/win32-arm64@0.21.5:
+  '@esbuild/win32-arm64@0.21.5':
     resolution: {integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@esbuild/win32-ia32@0.21.5:
+  '@esbuild/win32-ia32@0.21.5':
     resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
     engines: {node: '>=12'}
     cpu: [ia32]
     os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@esbuild/win32-x64@0.21.5:
+  '@esbuild/win32-x64@0.21.5':
     resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@jridgewell/sourcemap-codec@1.5.0:
+  '@jridgewell/sourcemap-codec@1.5.0':
     resolution: {integrity: sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==}
 
-  /@rollup/rollup-android-arm-eabi@4.19.2:
+  '@rollup/rollup-android-arm-eabi@4.19.2':
     resolution: {integrity: sha512-OHflWINKtoCFSpm/WmuQaWW4jeX+3Qt3XQDepkkiFTsoxFc5BpF3Z5aDxFZgBqRjO6ATP5+b1iilp4kGIZVWlA==}
     cpu: [arm]
     os: [android]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@rollup/rollup-android-arm64@4.19.2:
+  '@rollup/rollup-android-arm64@4.19.2':
     resolution: {integrity: sha512-k0OC/b14rNzMLDOE6QMBCjDRm3fQOHAL8Ldc9bxEWvMo4Ty9RY6rWmGetNTWhPo+/+FNd1lsQYRd0/1OSix36A==}
     cpu: [arm64]
     os: [android]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@rollup/rollup-darwin-arm64@4.19.2:
+  '@rollup/rollup-darwin-arm64@4.19.2':
     resolution: {integrity: sha512-IIARRgWCNWMTeQH+kr/gFTHJccKzwEaI0YSvtqkEBPj7AshElFq89TyreKNFAGh5frLfDCbodnq+Ye3dqGKPBw==}
     cpu: [arm64]
     os: [darwin]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@rollup/rollup-darwin-x64@4.19.2:
+  '@rollup/rollup-darwin-x64@4.19.2':
     resolution: {integrity: sha512-52udDMFDv54BTAdnw+KXNF45QCvcJOcYGl3vQkp4vARyrcdI/cXH8VXTEv/8QWfd6Fru8QQuw1b2uNersXOL0g==}
     cpu: [x64]
     os: [darwin]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@rollup/rollup-linux-arm-gnueabihf@4.19.2:
+  '@rollup/rollup-linux-arm-gnueabihf@4.19.2':
     resolution: {integrity: sha512-r+SI2t8srMPYZeoa1w0o/AfoVt9akI1ihgazGYPQGRilVAkuzMGiTtexNZkrPkQsyFrvqq/ni8f3zOnHw4hUbA==}
     cpu: [arm]
     os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@rollup/rollup-linux-arm-musleabihf@4.19.2:
+  '@rollup/rollup-linux-arm-musleabihf@4.19.2':
     resolution: {integrity: sha512-+tYiL4QVjtI3KliKBGtUU7yhw0GMcJJuB9mLTCEauHEsqfk49gtUBXGtGP3h1LW8MbaTY6rSFIQV1XOBps1gBA==}
     cpu: [arm]
     os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@rollup/rollup-linux-arm64-gnu@4.19.2:
+  '@rollup/rollup-linux-arm64-gnu@4.19.2':
     resolution: {integrity: sha512-OR5DcvZiYN75mXDNQQxlQPTv4D+uNCUsmSCSY2FolLf9W5I4DSoJyg7z9Ea3TjKfhPSGgMJiey1aWvlWuBzMtg==}
     cpu: [arm64]
     os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@rollup/rollup-linux-arm64-musl@4.19.2:
+  '@rollup/rollup-linux-arm64-musl@4.19.2':
     resolution: {integrity: sha512-Hw3jSfWdUSauEYFBSFIte6I8m6jOj+3vifLg8EU3lreWulAUpch4JBjDMtlKosrBzkr0kwKgL9iCfjA8L3geoA==}
     cpu: [arm64]
     os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@rollup/rollup-linux-powerpc64le-gnu@4.19.2:
+  '@rollup/rollup-linux-powerpc64le-gnu@4.19.2':
     resolution: {integrity: sha512-rhjvoPBhBwVnJRq/+hi2Q3EMiVF538/o9dBuj9TVLclo9DuONqt5xfWSaE6MYiFKpo/lFPJ/iSI72rYWw5Hc7w==}
     cpu: [ppc64]
     os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@rollup/rollup-linux-riscv64-gnu@4.19.2:
+  '@rollup/rollup-linux-riscv64-gnu@4.19.2':
     resolution: {integrity: sha512-EAz6vjPwHHs2qOCnpQkw4xs14XJq84I81sDRGPEjKPFVPBw7fwvtwhVjcZR6SLydCv8zNK8YGFblKWd/vRmP8g==}
     cpu: [riscv64]
     os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@rollup/rollup-linux-s390x-gnu@4.19.2:
+  '@rollup/rollup-linux-s390x-gnu@4.19.2':
     resolution: {integrity: sha512-IJSUX1xb8k/zN9j2I7B5Re6B0NNJDJ1+soezjNojhT8DEVeDNptq2jgycCOpRhyGj0+xBn7Cq+PK7Q+nd2hxLA==}
     cpu: [s390x]
     os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@rollup/rollup-linux-x64-gnu@4.19.2:
+  '@rollup/rollup-linux-x64-gnu@4.19.2':
     resolution: {integrity: sha512-OgaToJ8jSxTpgGkZSkwKE+JQGihdcaqnyHEFOSAU45utQ+yLruE1dkonB2SDI8t375wOKgNn8pQvaWY9kPzxDQ==}
     cpu: [x64]
     os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@rollup/rollup-linux-x64-musl@4.19.2:
+  '@rollup/rollup-linux-x64-musl@4.19.2':
     resolution: {integrity: sha512-5V3mPpWkB066XZZBgSd1lwozBk7tmOkKtquyCJ6T4LN3mzKENXyBwWNQn8d0Ci81hvlBw5RoFgleVpL6aScLYg==}
     cpu: [x64]
     os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@rollup/rollup-win32-arm64-msvc@4.19.2:
+  '@rollup/rollup-win32-arm64-msvc@4.19.2':
     resolution: {integrity: sha512-ayVstadfLeeXI9zUPiKRVT8qF55hm7hKa+0N1V6Vj+OTNFfKSoUxyZvzVvgtBxqSb5URQ8sK6fhwxr9/MLmxdA==}
     cpu: [arm64]
     os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@rollup/rollup-win32-ia32-msvc@4.19.2:
+  '@rollup/rollup-win32-ia32-msvc@4.19.2':
     resolution: {integrity: sha512-Mda7iG4fOLHNsPqjWSjANvNZYoW034yxgrndof0DwCy0D3FvTjeNo+HGE6oGWgvcLZNLlcp0hLEFcRs+UGsMLg==}
     cpu: [ia32]
     os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@rollup/rollup-win32-x64-msvc@4.19.2:
+  '@rollup/rollup-win32-x64-msvc@4.19.2':
     resolution: {integrity: sha512-DPi0ubYhSow/00YqmG1jWm3qt1F8aXziHc/UNy8bo9cpCacqhuWu+iSq/fp2SyEQK7iYTZ60fBU9cat3MXTjIQ==}
     cpu: [x64]
     os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /@types/chrome@0.0.269:
+  '@types/chrome@0.0.269':
     resolution: {integrity: sha512-vF7x8YywnhXX2F06njQ/OE7a3Qeful43C5GUOsUksXWk89WoSFUU3iLeZW8lDpVO9atm8iZIEiLQTRC3H7NOXQ==}
-    dependencies:
-      '@types/filesystem': 0.0.36
-      '@types/har-format': 1.2.15
-    dev: false
 
-  /@types/estree@1.0.5:
+  '@types/estree@1.0.5':
     resolution: {integrity: sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==}
-    dev: true
 
-  /@types/filesystem@0.0.36:
+  '@types/filesystem@0.0.36':
     resolution: {integrity: sha512-vPDXOZuannb9FZdxgHnqSwAG/jvdGM8Wq+6N4D/d80z+D4HWH+bItqsZaVRQykAn6WEVeEkLm2oQigyHtgb0RA==}
-    dependencies:
-      '@types/filewriter': 0.0.33
-    dev: false
 
-  /@types/filewriter@0.0.33:
+  '@types/filewriter@0.0.33':
     resolution: {integrity: sha512-xFU8ZXTw4gd358lb2jw25nxY9QAgqn2+bKKjKOYfNCzN4DKCFetK7sPtrlpg66Ywe3vWY9FNxprZawAh9wfJ3g==}
-    dev: false
 
-  /@types/har-format@1.2.15:
+  '@types/har-format@1.2.15':
     resolution: {integrity: sha512-RpQH4rXLuvTXKR0zqHq3go0RVXYv/YVqv4TnPH95VbwUxZdQlK1EtcMvQvMpDngHbt13Csh9Z4qT9AbkiQH5BA==}
-    dev: false
 
-  /@types/node@22.0.2:
+  '@types/node@22.0.2':
     resolution: {integrity: sha512-yPL6DyFwY5PiMVEwymNeqUTKsDczQBJ/5T7W/46RwLU/VH+AA8aT5TZkvBviLKLbbm0hlfftEkGrNzfRk/fofQ==}
-    dependencies:
-      undici-types: 6.11.1
-    dev: true
 
-  /@vitejs/plugin-vue@5.1.2(vite@5.3.5)(vue@3.4.35):
+  '@vitejs/plugin-vue@5.1.2':
     resolution: {integrity: sha512-nY9IwH12qeiJqumTCLJLE7IiNx7HZ39cbHaysEUd+Myvbz9KAqd2yq+U01Kab1R/H1BmiyM2ShTYlNH32Fzo3A==}
     engines: {node: ^18.0.0 || >=20.0.0}
     peerDependencies:
       vite: ^5.0.0
       vue: ^3.2.25
-    dependencies:
-      vite: 5.3.5(@types/node@22.0.2)
-      vue: 3.4.35(typescript@5.5.4)
-    dev: true
 
-  /@volar/language-core@2.4.0-alpha.18:
+  '@volar/language-core@2.4.0-alpha.18':
     resolution: {integrity: sha512-JAYeJvYQQROmVRtSBIczaPjP3DX4QW1fOqW1Ebs0d3Y3EwSNRglz03dSv0Dm61dzd0Yx3WgTW3hndDnTQqgmyg==}
-    dependencies:
-      '@volar/source-map': 2.4.0-alpha.18
-    dev: true
 
-  /@volar/source-map@2.4.0-alpha.18:
+  '@volar/source-map@2.4.0-alpha.18':
     resolution: {integrity: sha512-MTeCV9MUwwsH0sNFiZwKtFrrVZUK6p8ioZs3xFzHc2cvDXHWlYN3bChdQtwKX+FY2HG6H3CfAu1pKijolzIQ8g==}
-    dev: true
 
-  /@volar/typescript@2.4.0-alpha.18:
+  '@volar/typescript@2.4.0-alpha.18':
     resolution: {integrity: sha512-sXh5Y8sqGUkgxpMWUGvRXggxYHAVxg0Pa1C42lQZuPDrW6vHJPR0VCK8Sr7WJsAW530HuNQT/ZIskmXtxjybMQ==}
-    dependencies:
-      '@volar/language-core': 2.4.0-alpha.18
-      path-browserify: 1.0.1
-      vscode-uri: 3.0.8
-    dev: true
 
-  /@vue/compiler-core@3.4.35:
+  '@vue/compiler-core@3.4.35':
     resolution: {integrity: sha512-gKp0zGoLnMYtw4uS/SJRRO7rsVggLjvot3mcctlMXunYNsX+aRJDqqw/lV5/gHK91nvaAAlWFgdVl020AW1Prg==}
-    dependencies:
-      '@babel/parser': 7.25.3
-      '@vue/shared': 3.4.35
-      entities: 4.5.0
-      estree-walker: 2.0.2
-      source-map-js: 1.2.0
 
-  /@vue/compiler-dom@3.4.35:
+  '@vue/compiler-dom@3.4.35':
     resolution: {integrity: sha512-pWIZRL76/oE/VMhdv/ovZfmuooEni6JPG1BFe7oLk5DZRo/ImydXijoZl/4kh2406boRQ7lxTYzbZEEXEhj9NQ==}
-    dependencies:
-      '@vue/compiler-core': 3.4.35
-      '@vue/shared': 3.4.35
 
-  /@vue/compiler-sfc@3.4.35:
+  '@vue/compiler-sfc@3.4.35':
     resolution: {integrity: sha512-xacnRS/h/FCsjsMfxBkzjoNxyxEyKyZfBch/P4vkLRvYJwe5ChXmZZrj8Dsed/752H2Q3JE8kYu9Uyha9J6PgA==}
-    dependencies:
-      '@babel/parser': 7.25.3
-      '@vue/compiler-core': 3.4.35
-      '@vue/compiler-dom': 3.4.35
-      '@vue/compiler-ssr': 3.4.35
-      '@vue/shared': 3.4.35
-      estree-walker: 2.0.2
-      magic-string: 0.30.11
-      postcss: 8.4.40
-      source-map-js: 1.2.0
 
-  /@vue/compiler-ssr@3.4.35:
+  '@vue/compiler-ssr@3.4.35':
     resolution: {integrity: sha512-7iynB+0KB1AAJKk/biENTV5cRGHRdbdaD7Mx3nWcm1W8bVD6QmnH3B4AHhQQ1qZHhqFwzEzMwiytXm3PX1e60A==}
-    dependencies:
-      '@vue/compiler-dom': 3.4.35
-      '@vue/shared': 3.4.35
 
-  /@vue/compiler-vue2@2.7.16:
+  '@vue/compiler-vue2@2.7.16':
     resolution: {integrity: sha512-qYC3Psj9S/mfu9uVi5WvNZIzq+xnXMhOwbTFKKDD7b1lhpnn71jXSFdTQ+WsIEk0ONCd7VV2IMm7ONl6tbQ86A==}
-    dependencies:
-      de-indent: 1.0.2
-      he: 1.2.0
-    dev: true
 
-  /@vue/devtools-api@6.6.3:
+  '@vue/devtools-api@6.6.3':
     resolution: {integrity: sha512-0MiMsFma/HqA6g3KLKn+AGpL1kgKhFWszC9U29NfpWK5LE7bjeXxySWJrOJ77hBz+TBrBQ7o4QJqbPbqbs8rJw==}
-    dev: false
 
-  /@vue/language-core@2.0.29(typescript@5.5.4):
+  '@vue/language-core@2.0.29':
     resolution: {integrity: sha512-o2qz9JPjhdoVj8D2+9bDXbaI4q2uZTHQA/dbyZT4Bj1FR9viZxDJnLcKVHfxdn6wsOzRgpqIzJEEmSSvgMvDTQ==}
     peerDependencies:
       typescript: '*'
     peerDependenciesMeta:
       typescript:
         optional: true
-    dependencies:
-      '@volar/language-core': 2.4.0-alpha.18
-      '@vue/compiler-dom': 3.4.35
-      '@vue/compiler-vue2': 2.7.16
-      '@vue/shared': 3.4.35
-      computeds: 0.0.1
-      minimatch: 9.0.5
-      muggle-string: 0.4.1
-      path-browserify: 1.0.1
-      typescript: 5.5.4
-    dev: true
 
-  /@vue/reactivity@3.4.35:
+  '@vue/reactivity@3.4.35':
     resolution: {integrity: sha512-Ggtz7ZZHakriKioveJtPlStYardwQH6VCs9V13/4qjHSQb/teE30LVJNrbBVs4+aoYGtTQKJbTe4CWGxVZrvEw==}
-    dependencies:
-      '@vue/shared': 3.4.35
 
-  /@vue/runtime-core@3.4.35:
+  '@vue/runtime-core@3.4.35':
     resolution: {integrity: sha512-D+BAjFoWwT5wtITpSxwqfWZiBClhBbR+bm0VQlWYFOadUUXFo+5wbe9ErXhLvwguPiLZdEF13QAWi2vP3ZD5tA==}
-    dependencies:
-      '@vue/reactivity': 3.4.35
-      '@vue/shared': 3.4.35
 
-  /@vue/runtime-dom@3.4.35:
+  '@vue/runtime-dom@3.4.35':
     resolution: {integrity: sha512-yGOlbos+MVhlS5NWBF2HDNgblG8e2MY3+GigHEyR/dREAluvI5tuUUgie3/9XeqhPE4LF0i2wjlduh5thnfOqw==}
-    dependencies:
-      '@vue/reactivity': 3.4.35
-      '@vue/runtime-core': 3.4.35
-      '@vue/shared': 3.4.35
-      csstype: 3.1.3
 
-  /@vue/server-renderer@3.4.35(vue@3.4.35):
+  '@vue/server-renderer@3.4.35':
     resolution: {integrity: sha512-iZ0e/u9mRE4T8tNhlo0tbA+gzVkgv8r5BX6s1kRbOZqfpq14qoIvCZ5gIgraOmYkMYrSEZgkkojFPr+Nyq/Mnw==}
     peerDependencies:
       vue: 3.4.35
-    dependencies:
-      '@vue/compiler-ssr': 3.4.35
-      '@vue/shared': 3.4.35
-      vue: 3.4.35(typescript@5.5.4)
 
-  /@vue/shared@3.4.35:
+  '@vue/shared@3.4.35':
     resolution: {integrity: sha512-hvuhBYYDe+b1G8KHxsQ0diDqDMA8D9laxWZhNAjE83VZb5UDaXl9Xnz7cGdDSyiHM90qqI/CyGMcpBpiDy6VVQ==}
 
-  /balanced-match@1.0.2:
+  balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
-    dev: true
 
-  /brace-expansion@2.0.1:
+  brace-expansion@2.0.1:
     resolution: {integrity: sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==}
-    dependencies:
-      balanced-match: 1.0.2
-    dev: true
 
-  /computeds@0.0.1:
+  computeds@0.0.1:
     resolution: {integrity: sha512-7CEBgcMjVmitjYo5q8JTJVra6X5mQ20uTThdK+0kR7UEaDrAWEQcRiBtWJzga4eRpP6afNwwLsX2SET2JhVB1Q==}
-    dev: true
 
-  /core-js@3.37.1:
+  core-js@3.37.1:
     resolution: {integrity: sha512-Xn6qmxrQZyB0FFY8E3bgRXei3lWDJHhvI+u0q9TKIYM49G8pAr0FgnnrFRAmsbptZL1yxRADVXn+x5AGsbBfyw==}
-    requiresBuild: true
-    dev: false
 
-  /csstype@3.1.3:
+  csstype@3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
 
-  /date-fns@3.6.0:
+  date-fns@3.6.0:
     resolution: {integrity: sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==}
-    dev: false
 
-  /de-indent@1.0.2:
+  de-indent@1.0.2:
     resolution: {integrity: sha512-e/1zu3xH5MQryN2zdVaF0OrdNLUbvWxzMbi+iNA6Bky7l1RoP8a2fIbRocyHclXt/arDrrR6lL3TqFD9pMQTsg==}
-    dev: true
 
-  /entities@4.5.0:
+  entities@4.5.0:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
     engines: {node: '>=0.12'}
 
-  /esbuild@0.21.5:
+  esbuild@0.21.5:
     resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
     engines: {node: '>=12'}
     hasBin: true
-    requiresBuild: true
-    optionalDependencies:
-      '@esbuild/aix-ppc64': 0.21.5
-      '@esbuild/android-arm': 0.21.5
-      '@esbuild/android-arm64': 0.21.5
-      '@esbuild/android-x64': 0.21.5
-      '@esbuild/darwin-arm64': 0.21.5
-      '@esbuild/darwin-x64': 0.21.5
-      '@esbuild/freebsd-arm64': 0.21.5
-      '@esbuild/freebsd-x64': 0.21.5
-      '@esbuild/linux-arm': 0.21.5
-      '@esbuild/linux-arm64': 0.21.5
-      '@esbuild/linux-ia32': 0.21.5
-      '@esbuild/linux-loong64': 0.21.5
-      '@esbuild/linux-mips64el': 0.21.5
-      '@esbuild/linux-ppc64': 0.21.5
-      '@esbuild/linux-riscv64': 0.21.5
-      '@esbuild/linux-s390x': 0.21.5
-      '@esbuild/linux-x64': 0.21.5
-      '@esbuild/netbsd-x64': 0.21.5
-      '@esbuild/openbsd-x64': 0.21.5
-      '@esbuild/sunos-x64': 0.21.5
-      '@esbuild/win32-arm64': 0.21.5
-      '@esbuild/win32-ia32': 0.21.5
-      '@esbuild/win32-x64': 0.21.5
-    dev: true
 
-  /estree-walker@2.0.2:
+  estree-walker@2.0.2:
     resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
 
-  /fsevents@2.3.3:
+  fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
-    requiresBuild: true
-    dev: true
-    optional: true
 
-  /he@1.2.0:
+  he@1.2.0:
     resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
     hasBin: true
-    dev: true
 
-  /magic-string@0.30.11:
+  magic-string@0.30.11:
     resolution: {integrity: sha512-+Wri9p0QHMy+545hKww7YAu5NyzF8iomPL/RQazugQ9+Ez4Ic3mERMd8ZTX5rfK944j+560ZJi8iAwgak1Ac7A==}
-    dependencies:
-      '@jridgewell/sourcemap-codec': 1.5.0
 
-  /minimatch@9.0.5:
+  minimatch@9.0.5:
     resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
     engines: {node: '>=16 || 14 >=14.17'}
-    dependencies:
-      brace-expansion: 2.0.1
-    dev: true
 
-  /muggle-string@0.4.1:
+  muggle-string@0.4.1:
     resolution: {integrity: sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==}
-    dev: true
 
-  /nanoid@3.3.7:
+  nanoid@3.3.7:
     resolution: {integrity: sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
-  /path-browserify@1.0.1:
+  path-browserify@1.0.1:
     resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
-    dev: true
 
-  /picocolors@1.0.1:
+  picocolors@1.0.1:
     resolution: {integrity: sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew==}
 
-  /pinia@2.2.0(typescript@5.5.4)(vue@3.4.35):
+  pinia@2.2.0:
     resolution: {integrity: sha512-iPrIh26GMqfpUlMOGyxuDowGmYousTecbTHFwT0xZ1zJvh23oQ+Cj99ZoPQA1TnUPhU6AuRPv6/drkTCJ0VHQA==}
     peerDependencies:
       '@vue/composition-api': ^1.4.0
@@ -679,77 +434,43 @@ packages:
         optional: true
       typescript:
         optional: true
-    dependencies:
-      '@vue/devtools-api': 6.6.3
-      typescript: 5.5.4
-      vue: 3.4.35(typescript@5.5.4)
-      vue-demi: 0.14.10(vue@3.4.35)
-    dev: false
 
-  /postcss@8.4.40:
+  postcss@8.4.40:
     resolution: {integrity: sha512-YF2kKIUzAofPMpfH6hOi2cGnv/HrUlfucspc7pDyvv7kGdqXrfj8SCl/t8owkEgKEuu8ZcRjSOxFxVLqwChZ2Q==}
     engines: {node: ^10 || ^12 || >=14}
-    dependencies:
-      nanoid: 3.3.7
-      picocolors: 1.0.1
-      source-map-js: 1.2.0
 
-  /prettier@3.3.3:
+  prettier@3.3.3:
     resolution: {integrity: sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==}
     engines: {node: '>=14'}
     hasBin: true
-    dev: true
 
-  /rollup@4.19.2:
+  rollup@4.19.2:
     resolution: {integrity: sha512-6/jgnN1svF9PjNYJ4ya3l+cqutg49vOZ4rVgsDKxdl+5gpGPnByFXWGyfH9YGx9i3nfBwSu1Iyu6vGwFFA0BdQ==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
-    dependencies:
-      '@types/estree': 1.0.5
-    optionalDependencies:
-      '@rollup/rollup-android-arm-eabi': 4.19.2
-      '@rollup/rollup-android-arm64': 4.19.2
-      '@rollup/rollup-darwin-arm64': 4.19.2
-      '@rollup/rollup-darwin-x64': 4.19.2
-      '@rollup/rollup-linux-arm-gnueabihf': 4.19.2
-      '@rollup/rollup-linux-arm-musleabihf': 4.19.2
-      '@rollup/rollup-linux-arm64-gnu': 4.19.2
-      '@rollup/rollup-linux-arm64-musl': 4.19.2
-      '@rollup/rollup-linux-powerpc64le-gnu': 4.19.2
-      '@rollup/rollup-linux-riscv64-gnu': 4.19.2
-      '@rollup/rollup-linux-s390x-gnu': 4.19.2
-      '@rollup/rollup-linux-x64-gnu': 4.19.2
-      '@rollup/rollup-linux-x64-musl': 4.19.2
-      '@rollup/rollup-win32-arm64-msvc': 4.19.2
-      '@rollup/rollup-win32-ia32-msvc': 4.19.2
-      '@rollup/rollup-win32-x64-msvc': 4.19.2
-      fsevents: 2.3.3
-    dev: true
 
-  /semver@7.6.3:
+  semver@7.6.3:
     resolution: {integrity: sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==}
     engines: {node: '>=10'}
     hasBin: true
-    dev: true
 
-  /source-map-js@1.2.0:
+  source-map-js@1.2.0:
     resolution: {integrity: sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==}
     engines: {node: '>=0.10.0'}
 
-  /to-fast-properties@2.0.0:
+  to-fast-properties@2.0.0:
     resolution: {integrity: sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==}
     engines: {node: '>=4'}
 
-  /typescript@5.5.4:
+  typescript@5.5.4:
     resolution: {integrity: sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==}
     engines: {node: '>=14.17'}
     hasBin: true
 
-  /undici-types@6.11.1:
+  undici-types@6.11.1:
     resolution: {integrity: sha512-mIDEX2ek50x0OlRgxryxsenE5XaQD4on5U2inY7RApK3SOJpofyw7uW2AyfMKkhAxXIceo2DeWGVGwyvng1GNQ==}
-    dev: true
 
-  /vite@5.3.5(@types/node@22.0.2):
+  vite@5.3.5:
     resolution: {integrity: sha512-MdjglKR6AQXQb9JGiS7Rc2wC6uMjcm7Go/NHNO63EwiJXfuk9PgqiP/n5IDJCziMkfw9n4Ubp7lttNwz+8ZVKA==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
@@ -776,6 +497,394 @@ packages:
         optional: true
       terser:
         optional: true
+
+  vscode-uri@3.0.8:
+    resolution: {integrity: sha512-AyFQ0EVmsOZOlAnxoFOGOq1SQDWAB7C6aqMGS23svWAllfOaxbuFvcT8D1i8z3Gyn8fraVeZNNmN6e9bxxXkKw==}
+
+  vue-demi@0.14.10:
+    resolution: {integrity: sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==}
+    engines: {node: '>=12'}
+    hasBin: true
+    peerDependencies:
+      '@vue/composition-api': ^1.0.0-rc.1
+      vue: ^3.0.0-0 || ^2.6.0
+    peerDependenciesMeta:
+      '@vue/composition-api':
+        optional: true
+
+  vue-tsc@2.0.29:
+    resolution: {integrity: sha512-MHhsfyxO3mYShZCGYNziSbc63x7cQ5g9kvijV7dRe1TTXBRLxXyL0FnXWpUF1xII2mJ86mwYpYsUmMwkmerq7Q==}
+    hasBin: true
+    peerDependencies:
+      typescript: '>=5.0.0'
+
+  vue@3.4.35:
+    resolution: {integrity: sha512-+fl/GLmI4GPileHftVlCdB7fUL4aziPcqTudpTGXCT8s+iZWuOCeNEB5haX6Uz2IpRrbEXOgIFbe+XciCuGbNQ==}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+snapshots:
+
+  '@babel/helper-string-parser@7.24.8': {}
+
+  '@babel/helper-validator-identifier@7.24.7': {}
+
+  '@babel/parser@7.25.3':
+    dependencies:
+      '@babel/types': 7.25.2
+
+  '@babel/types@7.25.2':
+    dependencies:
+      '@babel/helper-string-parser': 7.24.8
+      '@babel/helper-validator-identifier': 7.24.7
+      to-fast-properties: 2.0.0
+
+  '@esbuild/aix-ppc64@0.21.5':
+    optional: true
+
+  '@esbuild/android-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/android-arm@0.21.5':
+    optional: true
+
+  '@esbuild/android-x64@0.21.5':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/darwin-x64@0.21.5':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-arm@0.21.5':
+    optional: true
+
+  '@esbuild/linux-ia32@0.21.5':
+    optional: true
+
+  '@esbuild/linux-loong64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.21.5':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-s390x@0.21.5':
+    optional: true
+
+  '@esbuild/linux-x64@0.21.5':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/sunos-x64@0.21.5':
+    optional: true
+
+  '@esbuild/win32-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/win32-ia32@0.21.5':
+    optional: true
+
+  '@esbuild/win32-x64@0.21.5':
+    optional: true
+
+  '@jridgewell/sourcemap-codec@1.5.0': {}
+
+  '@rollup/rollup-android-arm-eabi@4.19.2':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.19.2':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.19.2':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.19.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.19.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.19.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.19.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.19.2':
+    optional: true
+
+  '@rollup/rollup-linux-powerpc64le-gnu@4.19.2':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.19.2':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.19.2':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.19.2':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.19.2':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.19.2':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.19.2':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.19.2':
+    optional: true
+
+  '@types/chrome@0.0.269':
+    dependencies:
+      '@types/filesystem': 0.0.36
+      '@types/har-format': 1.2.15
+
+  '@types/estree@1.0.5': {}
+
+  '@types/filesystem@0.0.36':
+    dependencies:
+      '@types/filewriter': 0.0.33
+
+  '@types/filewriter@0.0.33': {}
+
+  '@types/har-format@1.2.15': {}
+
+  '@types/node@22.0.2':
+    dependencies:
+      undici-types: 6.11.1
+
+  '@vitejs/plugin-vue@5.1.2(vite@5.3.5)(vue@3.4.35)':
+    dependencies:
+      vite: 5.3.5(@types/node@22.0.2)
+      vue: 3.4.35(typescript@5.5.4)
+
+  '@volar/language-core@2.4.0-alpha.18':
+    dependencies:
+      '@volar/source-map': 2.4.0-alpha.18
+
+  '@volar/source-map@2.4.0-alpha.18': {}
+
+  '@volar/typescript@2.4.0-alpha.18':
+    dependencies:
+      '@volar/language-core': 2.4.0-alpha.18
+      path-browserify: 1.0.1
+      vscode-uri: 3.0.8
+
+  '@vue/compiler-core@3.4.35':
+    dependencies:
+      '@babel/parser': 7.25.3
+      '@vue/shared': 3.4.35
+      entities: 4.5.0
+      estree-walker: 2.0.2
+      source-map-js: 1.2.0
+
+  '@vue/compiler-dom@3.4.35':
+    dependencies:
+      '@vue/compiler-core': 3.4.35
+      '@vue/shared': 3.4.35
+
+  '@vue/compiler-sfc@3.4.35':
+    dependencies:
+      '@babel/parser': 7.25.3
+      '@vue/compiler-core': 3.4.35
+      '@vue/compiler-dom': 3.4.35
+      '@vue/compiler-ssr': 3.4.35
+      '@vue/shared': 3.4.35
+      estree-walker: 2.0.2
+      magic-string: 0.30.11
+      postcss: 8.4.40
+      source-map-js: 1.2.0
+
+  '@vue/compiler-ssr@3.4.35':
+    dependencies:
+      '@vue/compiler-dom': 3.4.35
+      '@vue/shared': 3.4.35
+
+  '@vue/compiler-vue2@2.7.16':
+    dependencies:
+      de-indent: 1.0.2
+      he: 1.2.0
+
+  '@vue/devtools-api@6.6.3': {}
+
+  '@vue/language-core@2.0.29(typescript@5.5.4)':
+    dependencies:
+      '@volar/language-core': 2.4.0-alpha.18
+      '@vue/compiler-dom': 3.4.35
+      '@vue/compiler-vue2': 2.7.16
+      '@vue/shared': 3.4.35
+      computeds: 0.0.1
+      minimatch: 9.0.5
+      muggle-string: 0.4.1
+      path-browserify: 1.0.1
+      typescript: 5.5.4
+
+  '@vue/reactivity@3.4.35':
+    dependencies:
+      '@vue/shared': 3.4.35
+
+  '@vue/runtime-core@3.4.35':
+    dependencies:
+      '@vue/reactivity': 3.4.35
+      '@vue/shared': 3.4.35
+
+  '@vue/runtime-dom@3.4.35':
+    dependencies:
+      '@vue/reactivity': 3.4.35
+      '@vue/runtime-core': 3.4.35
+      '@vue/shared': 3.4.35
+      csstype: 3.1.3
+
+  '@vue/server-renderer@3.4.35(vue@3.4.35)':
+    dependencies:
+      '@vue/compiler-ssr': 3.4.35
+      '@vue/shared': 3.4.35
+      vue: 3.4.35(typescript@5.5.4)
+
+  '@vue/shared@3.4.35': {}
+
+  balanced-match@1.0.2: {}
+
+  brace-expansion@2.0.1:
+    dependencies:
+      balanced-match: 1.0.2
+
+  computeds@0.0.1: {}
+
+  core-js@3.37.1: {}
+
+  csstype@3.1.3: {}
+
+  date-fns@3.6.0: {}
+
+  de-indent@1.0.2: {}
+
+  entities@4.5.0: {}
+
+  esbuild@0.21.5:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.21.5
+      '@esbuild/android-arm': 0.21.5
+      '@esbuild/android-arm64': 0.21.5
+      '@esbuild/android-x64': 0.21.5
+      '@esbuild/darwin-arm64': 0.21.5
+      '@esbuild/darwin-x64': 0.21.5
+      '@esbuild/freebsd-arm64': 0.21.5
+      '@esbuild/freebsd-x64': 0.21.5
+      '@esbuild/linux-arm': 0.21.5
+      '@esbuild/linux-arm64': 0.21.5
+      '@esbuild/linux-ia32': 0.21.5
+      '@esbuild/linux-loong64': 0.21.5
+      '@esbuild/linux-mips64el': 0.21.5
+      '@esbuild/linux-ppc64': 0.21.5
+      '@esbuild/linux-riscv64': 0.21.5
+      '@esbuild/linux-s390x': 0.21.5
+      '@esbuild/linux-x64': 0.21.5
+      '@esbuild/netbsd-x64': 0.21.5
+      '@esbuild/openbsd-x64': 0.21.5
+      '@esbuild/sunos-x64': 0.21.5
+      '@esbuild/win32-arm64': 0.21.5
+      '@esbuild/win32-ia32': 0.21.5
+      '@esbuild/win32-x64': 0.21.5
+
+  estree-walker@2.0.2: {}
+
+  fsevents@2.3.3:
+    optional: true
+
+  he@1.2.0: {}
+
+  magic-string@0.30.11:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.0
+
+  minimatch@9.0.5:
+    dependencies:
+      brace-expansion: 2.0.1
+
+  muggle-string@0.4.1: {}
+
+  nanoid@3.3.7: {}
+
+  path-browserify@1.0.1: {}
+
+  picocolors@1.0.1: {}
+
+  pinia@2.2.0(typescript@5.5.4)(vue@3.4.35):
+    dependencies:
+      '@vue/devtools-api': 6.6.3
+      typescript: 5.5.4
+      vue: 3.4.35(typescript@5.5.4)
+      vue-demi: 0.14.10(vue@3.4.35)
+
+  postcss@8.4.40:
+    dependencies:
+      nanoid: 3.3.7
+      picocolors: 1.0.1
+      source-map-js: 1.2.0
+
+  prettier@3.3.3: {}
+
+  rollup@4.19.2:
+    dependencies:
+      '@types/estree': 1.0.5
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.19.2
+      '@rollup/rollup-android-arm64': 4.19.2
+      '@rollup/rollup-darwin-arm64': 4.19.2
+      '@rollup/rollup-darwin-x64': 4.19.2
+      '@rollup/rollup-linux-arm-gnueabihf': 4.19.2
+      '@rollup/rollup-linux-arm-musleabihf': 4.19.2
+      '@rollup/rollup-linux-arm64-gnu': 4.19.2
+      '@rollup/rollup-linux-arm64-musl': 4.19.2
+      '@rollup/rollup-linux-powerpc64le-gnu': 4.19.2
+      '@rollup/rollup-linux-riscv64-gnu': 4.19.2
+      '@rollup/rollup-linux-s390x-gnu': 4.19.2
+      '@rollup/rollup-linux-x64-gnu': 4.19.2
+      '@rollup/rollup-linux-x64-musl': 4.19.2
+      '@rollup/rollup-win32-arm64-msvc': 4.19.2
+      '@rollup/rollup-win32-ia32-msvc': 4.19.2
+      '@rollup/rollup-win32-x64-msvc': 4.19.2
+      fsevents: 2.3.3
+
+  semver@7.6.3: {}
+
+  source-map-js@1.2.0: {}
+
+  to-fast-properties@2.0.0: {}
+
+  typescript@5.5.4: {}
+
+  undici-types@6.11.1: {}
+
+  vite@5.3.5(@types/node@22.0.2):
     dependencies:
       '@types/node': 22.0.2
       esbuild: 0.21.5
@@ -783,46 +892,21 @@ packages:
       rollup: 4.19.2
     optionalDependencies:
       fsevents: 2.3.3
-    dev: true
 
-  /vscode-uri@3.0.8:
-    resolution: {integrity: sha512-AyFQ0EVmsOZOlAnxoFOGOq1SQDWAB7C6aqMGS23svWAllfOaxbuFvcT8D1i8z3Gyn8fraVeZNNmN6e9bxxXkKw==}
-    dev: true
+  vscode-uri@3.0.8: {}
 
-  /vue-demi@0.14.10(vue@3.4.35):
-    resolution: {integrity: sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==}
-    engines: {node: '>=12'}
-    hasBin: true
-    requiresBuild: true
-    peerDependencies:
-      '@vue/composition-api': ^1.0.0-rc.1
-      vue: ^3.0.0-0 || ^2.6.0
-    peerDependenciesMeta:
-      '@vue/composition-api':
-        optional: true
+  vue-demi@0.14.10(vue@3.4.35):
     dependencies:
       vue: 3.4.35(typescript@5.5.4)
-    dev: false
 
-  /vue-tsc@2.0.29(typescript@5.5.4):
-    resolution: {integrity: sha512-MHhsfyxO3mYShZCGYNziSbc63x7cQ5g9kvijV7dRe1TTXBRLxXyL0FnXWpUF1xII2mJ86mwYpYsUmMwkmerq7Q==}
-    hasBin: true
-    peerDependencies:
-      typescript: '>=5.0.0'
+  vue-tsc@2.0.29(typescript@5.5.4):
     dependencies:
       '@volar/typescript': 2.4.0-alpha.18
       '@vue/language-core': 2.0.29(typescript@5.5.4)
       semver: 7.6.3
       typescript: 5.5.4
-    dev: true
 
-  /vue@3.4.35(typescript@5.5.4):
-    resolution: {integrity: sha512-+fl/GLmI4GPileHftVlCdB7fUL4aziPcqTudpTGXCT8s+iZWuOCeNEB5haX6Uz2IpRrbEXOgIFbe+XciCuGbNQ==}
-    peerDependencies:
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
+  vue@3.4.35(typescript@5.5.4):
     dependencies:
       '@vue/compiler-dom': 3.4.35
       '@vue/compiler-sfc': 3.4.35

--- a/src/assets/styles/global.css
+++ b/src/assets/styles/global.css
@@ -162,8 +162,18 @@ body {
 }
 
 body {
-	font-family: var(--font), -apple-system, BlinkMacSystemFont, 'Segoe UI',
-		Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+	font-family:
+		var(--font),
+		-apple-system,
+		BlinkMacSystemFont,
+		'Segoe UI',
+		Roboto,
+		Oxygen,
+		Ubuntu,
+		Cantarell,
+		'Open Sans',
+		'Helvetica Neue',
+		sans-serif;
 	-webkit-font-smoothing: antialiased;
 	-moz-osx-font-smoothing: grayscale;
 	background-color: var(--theme-bg);

--- a/src/assets/styles/global.css
+++ b/src/assets/styles/global.css
@@ -41,6 +41,9 @@
 	--ui-fg: var(--color-gray);
 	--ui-bg: white;
 
+	/* custom color */
+	--color-custom: #3a3441;
+
 	--ui-focus-box: 0px 0px 0px 2px var(--ui-bg), 0px 0px 0px 4px var(--ui-fg);
 }
 
@@ -63,6 +66,9 @@
 .sand:root {
 	--theme-bg: var(--color-sand);
 }
+.custom:root {
+	--theme-bg: var(--color-custom);
+}
 
 /* dark classic themes: with [name]-dark class */
 .lavender-dark:root,
@@ -70,7 +76,8 @@
 .lemon-dark:root,
 .sea-dark:root,
 .leaf-dark:root,
-.sand-dark:root {
+.sand-dark:root,
+.custom-dark:root {
 	--theme-fg: var(--color-sand);
 	--ui-bg: var(--color-sand);
 }
@@ -91,6 +98,9 @@
 }
 .sand-dark:root {
 	--theme-bg: var(--color-sand-dark);
+}
+.custom-dark:root {
+	--theme-bg: var(--color-custom);
 }
 
 /* system themes: with [name]-system class */

--- a/src/assets/styles/normalize.css
+++ b/src/assets/styles/normalize.css
@@ -568,8 +568,8 @@ pre,
 code,
 kbd,
 samp {
-	font-family:
-		Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+	font-family: Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New',
+		monospace;
 }
 
 /**

--- a/src/assets/styles/normalize.css
+++ b/src/assets/styles/normalize.css
@@ -568,8 +568,8 @@ pre,
 code,
 kbd,
 samp {
-	font-family: Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New',
-		monospace;
+	font-family:
+		Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
 }
 
 /**

--- a/src/components/options.vue
+++ b/src/components/options.vue
@@ -10,6 +10,7 @@ import { ref } from 'vue'
 import { useDataStore } from '../store/data'
 import { useOptionsStore } from '../store/options'
 import { useInstanceStore } from '../store/instance'
+import { isColorDark } from '../utils/helpers'
 
 const dataStore = useDataStore()
 const optionsStore = useOptionsStore()
@@ -21,6 +22,18 @@ let themes = ['lavender', 'rose', 'lemon', 'sea', 'leaf', 'sand']
 
 function toggleOptionsMenu() {
 	isOptionsOpen.value = !isOptionsOpen.value
+}
+
+const isCustomColorDark = isColorDark(optionsStore.theme.customColor)
+const customColorScheme = isCustomColorDark ? 'custom-dark' : 'custom'
+
+function handleCustomColorChange(e: Event) {
+	const target = e.target as HTMLInputElement
+	let color = target.value
+	if (color && !color.startsWith('#')) {
+		color = '#' + color
+	}
+	optionsStore.setCustomColor(color)
 }
 
 function handleFetch() {
@@ -45,11 +58,7 @@ function handleClearData() {
 	<!-- todo: consider updating typography-->
 	<!-- todo: consider adding font selection (sans serif, mono) -->
 	<div class="options" @keyup.esc="isOptionsOpen = false">
-		<button
-			:class="{ open: isOptionsOpen }"
-			class="options-button"
-			@click="toggleOptionsMenu"
-		>
+		<button :class="{ open: isOptionsOpen }" class="options-button" @click="toggleOptionsMenu">
 			<Icon class="options-icon" />
 		</button>
 		<div v-if="isOptionsOpen" class="overlay" @click="toggleOptionsMenu" />
@@ -72,11 +81,7 @@ function handleClearData() {
 					<div class="space-xsmall" />
 					<ul class="theme-list">
 						<li v-for="theme in themes">
-							<ThemeSelect
-								:theme="theme + '-dark'"
-								:colors="[theme + '-dark']"
-								dark
-							/>
+							<ThemeSelect :theme="theme + '-dark'" :colors="[theme + '-dark']" dark />
 						</li>
 					</ul>
 					<div class="space-xsmall" />
@@ -84,13 +89,16 @@ function handleClearData() {
 					<div class="space-xsmall" />
 					<ul class="theme-list">
 						<li v-for="theme in themes">
-							<ThemeSelect
-								:theme="theme + '-system'"
-								split
-								:colors="[theme, `${theme}-dark`]"
-								dark
-							/>
+							<ThemeSelect :theme="theme + '-system'" split :colors="[theme, `${theme}-dark`]" dark />
 						</li>
+					</ul>
+					<div class="space-xsmall" />
+					<div :class="text.label">Custom</div>
+					<div class="space-xsmall" />
+					<ul class="custom-theme-menu">
+						<ThemeSelect :theme="customColorScheme" :dark="isCustomColorDark" :colors="['custom', 'custom-dark']" />
+						<input type="text" :value="optionsStore.theme.customColor" @input="handleCustomColorChange"
+							placeholder="#3a3441" :class="text.title" />
 					</ul>
 				</div>
 
@@ -121,11 +129,7 @@ function handleClearData() {
 					</template>
 				</RadioGroup>
 
-				<OptionToggle
-					option="time.use24Hour"
-					label="24-hour format"
-					role="menuitem"
-				/>
+				<OptionToggle option="time.use24Hour" label="24-hour format" role="menuitem" />
 
 				<div class="divider" />
 
@@ -135,9 +139,7 @@ function handleClearData() {
 
 				<div class="row">
 					<div :class="text.base">Source:</div>
-					<ExternalLink url="https://openweathermap.org"
-						>OpenWeather</ExternalLink
-					>
+					<ExternalLink url="https://openweathermap.org">OpenWeather</ExternalLink>
 				</div>
 
 				<div class="divider" />
@@ -151,12 +153,7 @@ function handleClearData() {
 					</div>
 					<div v-else :class="text.label">Fetching...</div>
 					<div>
-						<button
-							:class="button.primary"
-							style="margin: 0 auto"
-							:disabled="refreshDisabled"
-							@click="handleFetch()"
-						>
+						<button :class="button.primary" style="margin: 0 auto" :disabled="refreshDisabled" @click="handleFetch()">
 							{{ !refreshDisabled ? 'Refresh' : 'Please wait 15s' }}
 						</button>
 					</div>
@@ -171,11 +168,7 @@ function handleClearData() {
 							}}
 						</div>
 						<div>
-							<button
-								:class="button.primary"
-								style="margin: 0 auto"
-								@click="handleFetch()"
-							>
+							<button :class="button.primary" style="margin: 0 auto" @click="handleFetch()">
 								Enable
 							</button>
 						</div>
@@ -192,16 +185,10 @@ function handleClearData() {
 				<div v-if="optionsStore.init && dataStore.isChromeExtension">
 					<div :class="text.subtitle">Data sync</div>
 
-					<OptionToggle
-						option="useChromeStorage"
-						label="Sync with Chrome"
-						role="menuitem"
-						:onChange="
-							() =>
-								!optionsStore.useChromeStorage &&
-								optionsStore.readChromeStorage()
-						"
-					/>
+					<OptionToggle option="useChromeStorage" label="Sync with Chrome" role="menuitem" :onChange="() =>
+						!optionsStore.useChromeStorage &&
+						optionsStore.readChromeStorage()
+						" />
 					<div :class="text.base">
 						Persist options across your Chrome browsers (overrides your current
 						options). Your location is not synced and will remain on-device.
@@ -223,26 +210,17 @@ function handleClearData() {
 				</div>
 
 				<div class="row even">
-					<ExternalLink
-						url="https://github.com/fvrests/lavender/blob/main/privacy-policy.md"
-						>Privacy Policy
+					<ExternalLink url="https://github.com/fvrests/lavender/blob/main/privacy-policy.md">Privacy Policy
 					</ExternalLink>
-					<ExternalLink
-						url="https://github.com/fvrests/lavender/blob/main/terms-of-use.md"
-						>Terms of Use</ExternalLink
-					>
+					<ExternalLink url="https://github.com/fvrests/lavender/blob/main/terms-of-use.md">Terms of Use</ExternalLink>
 				</div>
 
 				<div class="space-small" />
 
 				<div class="row even">
-					<ExternalLink url="https://fvrests.dev" :underline="true"
-						>fvrests</ExternalLink
-					>
+					<ExternalLink url="https://fvrests.dev" :underline="true">fvrests</ExternalLink>
 
-					<ExternalLink url="https://ko-fi.com/fvrests" :underline="true"
-						>donate ♥</ExternalLink
-					>
+					<ExternalLink url="https://ko-fi.com/fvrests" :underline="true">donate ♥</ExternalLink>
 				</div>
 			</div>
 		</transition>
@@ -262,9 +240,7 @@ function handleClearData() {
 
 .options-menu {
 	--_space-around: var(--page-padding);
-	--_space-around-bottom: calc(
-		var(--_space-around) + 36px + var(--space-small)
-	);
+	--_space-around-bottom: calc(var(--_space-around) + 36px + var(--space-small));
 
 	margin-top: var(--_space-around);
 	color: var(--ui-fg);
@@ -347,11 +323,31 @@ function handleClearData() {
 	padding: 4px;
 }
 
+.custom-theme-menu {
+	display: flex;
+	align-items: center;
+	gap: var(--space-xsmall);
+}
+
+input {
+	width: 100%;
+	height: 30px;
+	border: var(--border);
+	border-radius: var(--rounded-full);
+	padding: 0 var(--space-xsmall);
+}
+
+input:focus {
+	outline: none;
+	box-shadow: var(--ui-focus-box);
+}
+
 .theme-list {
 	display: grid;
 	grid-template-columns: repeat(6, 1fr);
 }
-.theme-list > * {
+
+.theme-list>* {
 	margin-right: auto;
 	display: inline-flex;
 }

--- a/src/components/options.vue
+++ b/src/components/options.vue
@@ -58,7 +58,11 @@ function handleClearData() {
 	<!-- todo: consider updating typography-->
 	<!-- todo: consider adding font selection (sans serif, mono) -->
 	<div class="options" @keyup.esc="isOptionsOpen = false">
-		<button :class="{ open: isOptionsOpen }" class="options-button" @click="toggleOptionsMenu">
+		<button
+			:class="{ open: isOptionsOpen }"
+			class="options-button"
+			@click="toggleOptionsMenu"
+		>
 			<Icon class="options-icon" />
 		</button>
 		<div v-if="isOptionsOpen" class="overlay" @click="toggleOptionsMenu" />
@@ -81,7 +85,11 @@ function handleClearData() {
 					<div class="space-xsmall" />
 					<ul class="theme-list">
 						<li v-for="theme in themes">
-							<ThemeSelect :theme="theme + '-dark'" :colors="[theme + '-dark']" dark />
+							<ThemeSelect
+								:theme="theme + '-dark'"
+								:colors="[theme + '-dark']"
+								dark
+							/>
 						</li>
 					</ul>
 					<div class="space-xsmall" />
@@ -89,16 +97,30 @@ function handleClearData() {
 					<div class="space-xsmall" />
 					<ul class="theme-list">
 						<li v-for="theme in themes">
-							<ThemeSelect :theme="theme + '-system'" split :colors="[theme, `${theme}-dark`]" dark />
+							<ThemeSelect
+								:theme="theme + '-system'"
+								split
+								:colors="[theme, `${theme}-dark`]"
+								dark
+							/>
 						</li>
 					</ul>
 					<div class="space-xsmall" />
 					<div :class="text.label">Custom</div>
 					<div class="space-xsmall" />
 					<ul class="custom-theme-menu">
-						<ThemeSelect :theme="customColorScheme" :dark="isCustomColorDark" :colors="['custom', 'custom-dark']" />
-						<input type="text" :value="optionsStore.theme.customColor" @input="handleCustomColorChange"
-							placeholder="#3a3441" :class="text.title" />
+						<ThemeSelect
+							:theme="customColorScheme"
+							:dark="isCustomColorDark"
+							:colors="['custom', 'custom-dark']"
+						/>
+						<input
+							type="text"
+							:value="optionsStore.theme.customColor"
+							@input="handleCustomColorChange"
+							placeholder="#3a3441"
+							:class="text.title"
+						/>
 					</ul>
 				</div>
 
@@ -129,7 +151,11 @@ function handleClearData() {
 					</template>
 				</RadioGroup>
 
-				<OptionToggle option="time.use24Hour" label="24-hour format" role="menuitem" />
+				<OptionToggle
+					option="time.use24Hour"
+					label="24-hour format"
+					role="menuitem"
+				/>
 
 				<div class="divider" />
 
@@ -139,7 +165,9 @@ function handleClearData() {
 
 				<div class="row">
 					<div :class="text.base">Source:</div>
-					<ExternalLink url="https://openweathermap.org">OpenWeather</ExternalLink>
+					<ExternalLink url="https://openweathermap.org"
+						>OpenWeather</ExternalLink
+					>
 				</div>
 
 				<div class="divider" />
@@ -153,7 +181,12 @@ function handleClearData() {
 					</div>
 					<div v-else :class="text.label">Fetching...</div>
 					<div>
-						<button :class="button.primary" style="margin: 0 auto" :disabled="refreshDisabled" @click="handleFetch()">
+						<button
+							:class="button.primary"
+							style="margin: 0 auto"
+							:disabled="refreshDisabled"
+							@click="handleFetch()"
+						>
 							{{ !refreshDisabled ? 'Refresh' : 'Please wait 15s' }}
 						</button>
 					</div>
@@ -168,7 +201,11 @@ function handleClearData() {
 							}}
 						</div>
 						<div>
-							<button :class="button.primary" style="margin: 0 auto" @click="handleFetch()">
+							<button
+								:class="button.primary"
+								style="margin: 0 auto"
+								@click="handleFetch()"
+							>
 								Enable
 							</button>
 						</div>
@@ -185,10 +222,16 @@ function handleClearData() {
 				<div v-if="optionsStore.init && dataStore.isChromeExtension">
 					<div :class="text.subtitle">Data sync</div>
 
-					<OptionToggle option="useChromeStorage" label="Sync with Chrome" role="menuitem" :onChange="() =>
-						!optionsStore.useChromeStorage &&
-						optionsStore.readChromeStorage()
-						" />
+					<OptionToggle
+						option="useChromeStorage"
+						label="Sync with Chrome"
+						role="menuitem"
+						:onChange="
+							() =>
+								!optionsStore.useChromeStorage &&
+								optionsStore.readChromeStorage()
+						"
+					/>
 					<div :class="text.base">
 						Persist options across your Chrome browsers (overrides your current
 						options). Your location is not synced and will remain on-device.
@@ -210,17 +253,26 @@ function handleClearData() {
 				</div>
 
 				<div class="row even">
-					<ExternalLink url="https://github.com/fvrests/lavender/blob/main/privacy-policy.md">Privacy Policy
+					<ExternalLink
+						url="https://github.com/fvrests/lavender/blob/main/privacy-policy.md"
+						>Privacy Policy
 					</ExternalLink>
-					<ExternalLink url="https://github.com/fvrests/lavender/blob/main/terms-of-use.md">Terms of Use</ExternalLink>
+					<ExternalLink
+						url="https://github.com/fvrests/lavender/blob/main/terms-of-use.md"
+						>Terms of Use</ExternalLink
+					>
 				</div>
 
 				<div class="space-small" />
 
 				<div class="row even">
-					<ExternalLink url="https://fvrests.dev" :underline="true">fvrests</ExternalLink>
+					<ExternalLink url="https://fvrests.dev" :underline="true"
+						>fvrests</ExternalLink
+					>
 
-					<ExternalLink url="https://ko-fi.com/fvrests" :underline="true">donate ♥</ExternalLink>
+					<ExternalLink url="https://ko-fi.com/fvrests" :underline="true"
+						>donate ♥</ExternalLink
+					>
 				</div>
 			</div>
 		</transition>
@@ -240,7 +292,9 @@ function handleClearData() {
 
 .options-menu {
 	--_space-around: var(--page-padding);
-	--_space-around-bottom: calc(var(--_space-around) + 36px + var(--space-small));
+	--_space-around-bottom: calc(
+		var(--_space-around) + 36px + var(--space-small)
+	);
 
 	margin-top: var(--_space-around);
 	color: var(--ui-fg);
@@ -347,7 +401,7 @@ input:focus {
 	grid-template-columns: repeat(6, 1fr);
 }
 
-.theme-list>* {
+.theme-list > * {
 	margin-right: auto;
 	display: inline-flex;
 }

--- a/src/components/options.vue
+++ b/src/components/options.vue
@@ -1,16 +1,16 @@
 <script setup lang="ts">
+import { computed, ref } from 'vue'
 import Icon from '../assets/icons/icon.vue'
-import OptionToggle from './option-toggle.vue'
-import RadioGroup from './radio-group.vue'
-import ExternalLink from './external-link.vue'
-import ThemeSelect from './theme-select.vue'
 import button from '../assets/styles/button.module.css'
 import text from '../assets/styles/text.module.css'
-import { ref } from 'vue'
 import { useDataStore } from '../store/data'
-import { useOptionsStore } from '../store/options'
 import { useInstanceStore } from '../store/instance'
+import { useOptionsStore } from '../store/options'
 import { isColorDark } from '../utils/helpers'
+import ExternalLink from './external-link.vue'
+import OptionToggle from './option-toggle.vue'
+import RadioGroup from './radio-group.vue'
+import ThemeSelect from './theme-select.vue'
 
 const dataStore = useDataStore()
 const optionsStore = useOptionsStore()
@@ -24,8 +24,12 @@ function toggleOptionsMenu() {
 	isOptionsOpen.value = !isOptionsOpen.value
 }
 
-const isCustomColorDark = isColorDark(optionsStore.theme.customColor)
-const customColorScheme = isCustomColorDark ? 'custom-dark' : 'custom'
+const isCustomColorDark = computed(() =>
+	isColorDark(optionsStore.theme.customColor),
+)
+const customColorScheme = computed(() =>
+	isCustomColorDark.value ? 'custom-dark' : 'custom',
+)
 
 function handleCustomColorChange(e: Event) {
 	const target = e.target as HTMLInputElement
@@ -33,6 +37,15 @@ function handleCustomColorChange(e: Event) {
 	if (color && !color.startsWith('#')) {
 		color = '#' + color
 	}
+
+	if (
+		color.length > 1 &&
+		color.at(0) === '#' &&
+		!/^#([0-9A-F]{3}){1,2}$/i.test(color)
+	) {
+		return
+	}
+
 	optionsStore.setCustomColor(color)
 }
 
@@ -119,6 +132,7 @@ function handleClearData() {
 							:value="optionsStore.theme.customColor"
 							@input="handleCustomColorChange"
 							placeholder="#3a3441"
+							maxlength="7"
 							:class="text.title"
 						/>
 					</ul>

--- a/src/components/options.vue
+++ b/src/components/options.vue
@@ -38,10 +38,7 @@ function handleCustomColorChange(e: Event) {
 		color = '#' + color
 	}
 
-	if (
-		color.length > 0 &&
-		!/^#([0-9A-F]{3}){1,2}$/i.test(color)
-	) {
+	if (color.length > 0 && !/^#([0-9A-F]{3}){1,2}$/i.test(color)) {
 		return
 	}
 
@@ -70,7 +67,11 @@ function handleClearData() {
 	<!-- todo: consider updating typography-->
 	<!-- todo: consider adding font selection (sans serif, mono) -->
 	<div class="options" @keyup.esc="isOptionsOpen = false">
-		<button :class="{ open: isOptionsOpen }" class="options-button" @click="toggleOptionsMenu">
+		<button
+			:class="{ open: isOptionsOpen }"
+			class="options-button"
+			@click="toggleOptionsMenu"
+		>
 			<Icon class="options-icon" />
 		</button>
 		<div v-if="isOptionsOpen" class="overlay" @click="toggleOptionsMenu" />
@@ -93,7 +94,11 @@ function handleClearData() {
 					<div class="space-xsmall" />
 					<ul class="theme-list">
 						<li v-for="theme in themes">
-							<ThemeSelect :theme="theme + '-dark'" :colors="[theme + '-dark']" dark />
+							<ThemeSelect
+								:theme="theme + '-dark'"
+								:colors="[theme + '-dark']"
+								dark
+							/>
 						</li>
 					</ul>
 					<div class="space-xsmall" />
@@ -101,16 +106,31 @@ function handleClearData() {
 					<div class="space-xsmall" />
 					<ul class="theme-list">
 						<li v-for="theme in themes">
-							<ThemeSelect :theme="theme + '-system'" split :colors="[theme, `${theme}-dark`]" dark />
+							<ThemeSelect
+								:theme="theme + '-system'"
+								split
+								:colors="[theme, `${theme}-dark`]"
+								dark
+							/>
 						</li>
 					</ul>
 					<div class="space-xsmall" />
 					<div :class="text.label">Custom</div>
 					<div class="space-xsmall" />
 					<ul class="custom-theme-menu">
-						<ThemeSelect :theme="customColorScheme" :dark="isCustomColorDark" :colors="['custom', 'custom-dark']" />
-						<input type="text" :value="optionsStore.theme.customColor" @input="handleCustomColorChange"
-							placeholder="#3a3441" maxlength="7" :class="text.title" />
+						<ThemeSelect
+							:theme="customColorScheme"
+							:dark="isCustomColorDark"
+							:colors="['custom', 'custom-dark']"
+						/>
+						<input
+							type="text"
+							:value="optionsStore.theme.customColor"
+							@input="handleCustomColorChange"
+							placeholder="#3a3441"
+							maxlength="7"
+							:class="text.title"
+						/>
 					</ul>
 				</div>
 
@@ -141,7 +161,11 @@ function handleClearData() {
 					</template>
 				</RadioGroup>
 
-				<OptionToggle option="time.use24Hour" label="24-hour format" role="menuitem" />
+				<OptionToggle
+					option="time.use24Hour"
+					label="24-hour format"
+					role="menuitem"
+				/>
 
 				<div class="divider" />
 
@@ -151,7 +175,9 @@ function handleClearData() {
 
 				<div class="row">
 					<div :class="text.base">Source:</div>
-					<ExternalLink url="https://openweathermap.org">OpenWeather</ExternalLink>
+					<ExternalLink url="https://openweathermap.org"
+						>OpenWeather</ExternalLink
+					>
 				</div>
 
 				<div class="divider" />
@@ -165,7 +191,12 @@ function handleClearData() {
 					</div>
 					<div v-else :class="text.label">Fetching...</div>
 					<div>
-						<button :class="button.primary" style="margin: 0 auto" :disabled="refreshDisabled" @click="handleFetch()">
+						<button
+							:class="button.primary"
+							style="margin: 0 auto"
+							:disabled="refreshDisabled"
+							@click="handleFetch()"
+						>
 							{{ !refreshDisabled ? 'Refresh' : 'Please wait 15s' }}
 						</button>
 					</div>
@@ -180,7 +211,11 @@ function handleClearData() {
 							}}
 						</div>
 						<div>
-							<button :class="button.primary" style="margin: 0 auto" @click="handleFetch()">
+							<button
+								:class="button.primary"
+								style="margin: 0 auto"
+								@click="handleFetch()"
+							>
 								Enable
 							</button>
 						</div>
@@ -197,10 +232,16 @@ function handleClearData() {
 				<div v-if="optionsStore.init && dataStore.isChromeExtension">
 					<div :class="text.subtitle">Data sync</div>
 
-					<OptionToggle option="useChromeStorage" label="Sync with Chrome" role="menuitem" :onChange="() =>
-							!optionsStore.useChromeStorage &&
-							optionsStore.readChromeStorage()
-						" />
+					<OptionToggle
+						option="useChromeStorage"
+						label="Sync with Chrome"
+						role="menuitem"
+						:onChange="
+							() =>
+								!optionsStore.useChromeStorage &&
+								optionsStore.readChromeStorage()
+						"
+					/>
 					<div :class="text.base">
 						Persist options across your Chrome browsers (overrides your current
 						options). Your location is not synced and will remain on-device.
@@ -222,17 +263,26 @@ function handleClearData() {
 				</div>
 
 				<div class="row even">
-					<ExternalLink url="https://github.com/fvrests/lavender/blob/main/privacy-policy.md">Privacy Policy
+					<ExternalLink
+						url="https://github.com/fvrests/lavender/blob/main/privacy-policy.md"
+						>Privacy Policy
 					</ExternalLink>
-					<ExternalLink url="https://github.com/fvrests/lavender/blob/main/terms-of-use.md">Terms of Use</ExternalLink>
+					<ExternalLink
+						url="https://github.com/fvrests/lavender/blob/main/terms-of-use.md"
+						>Terms of Use</ExternalLink
+					>
 				</div>
 
 				<div class="space-small" />
 
 				<div class="row even">
-					<ExternalLink url="https://fvrests.dev" :underline="true">fvrests</ExternalLink>
+					<ExternalLink url="https://fvrests.dev" :underline="true"
+						>fvrests</ExternalLink
+					>
 
-					<ExternalLink url="https://ko-fi.com/fvrests" :underline="true">donate ♥</ExternalLink>
+					<ExternalLink url="https://ko-fi.com/fvrests" :underline="true"
+						>donate ♥</ExternalLink
+					>
 				</div>
 			</div>
 		</transition>
@@ -252,7 +302,9 @@ function handleClearData() {
 
 .options-menu {
 	--_space-around: var(--page-padding);
-	--_space-around-bottom: calc(var(--_space-around) + 36px + var(--space-small));
+	--_space-around-bottom: calc(
+		var(--_space-around) + 36px + var(--space-small)
+	);
 
 	margin-top: var(--_space-around);
 	color: var(--ui-fg);
@@ -359,7 +411,7 @@ input:focus {
 	grid-template-columns: repeat(6, 1fr);
 }
 
-.theme-list>* {
+.theme-list > * {
 	margin-right: auto;
 	display: inline-flex;
 }

--- a/src/components/options.vue
+++ b/src/components/options.vue
@@ -39,8 +39,7 @@ function handleCustomColorChange(e: Event) {
 	}
 
 	if (
-		color.length > 1 &&
-		color.at(0) === '#' &&
+		color.length > 0 &&
 		!/^#([0-9A-F]{3}){1,2}$/i.test(color)
 	) {
 		return
@@ -71,11 +70,7 @@ function handleClearData() {
 	<!-- todo: consider updating typography-->
 	<!-- todo: consider adding font selection (sans serif, mono) -->
 	<div class="options" @keyup.esc="isOptionsOpen = false">
-		<button
-			:class="{ open: isOptionsOpen }"
-			class="options-button"
-			@click="toggleOptionsMenu"
-		>
+		<button :class="{ open: isOptionsOpen }" class="options-button" @click="toggleOptionsMenu">
 			<Icon class="options-icon" />
 		</button>
 		<div v-if="isOptionsOpen" class="overlay" @click="toggleOptionsMenu" />
@@ -98,11 +93,7 @@ function handleClearData() {
 					<div class="space-xsmall" />
 					<ul class="theme-list">
 						<li v-for="theme in themes">
-							<ThemeSelect
-								:theme="theme + '-dark'"
-								:colors="[theme + '-dark']"
-								dark
-							/>
+							<ThemeSelect :theme="theme + '-dark'" :colors="[theme + '-dark']" dark />
 						</li>
 					</ul>
 					<div class="space-xsmall" />
@@ -110,31 +101,16 @@ function handleClearData() {
 					<div class="space-xsmall" />
 					<ul class="theme-list">
 						<li v-for="theme in themes">
-							<ThemeSelect
-								:theme="theme + '-system'"
-								split
-								:colors="[theme, `${theme}-dark`]"
-								dark
-							/>
+							<ThemeSelect :theme="theme + '-system'" split :colors="[theme, `${theme}-dark`]" dark />
 						</li>
 					</ul>
 					<div class="space-xsmall" />
 					<div :class="text.label">Custom</div>
 					<div class="space-xsmall" />
 					<ul class="custom-theme-menu">
-						<ThemeSelect
-							:theme="customColorScheme"
-							:dark="isCustomColorDark"
-							:colors="['custom', 'custom-dark']"
-						/>
-						<input
-							type="text"
-							:value="optionsStore.theme.customColor"
-							@input="handleCustomColorChange"
-							placeholder="#3a3441"
-							maxlength="7"
-							:class="text.title"
-						/>
+						<ThemeSelect :theme="customColorScheme" :dark="isCustomColorDark" :colors="['custom', 'custom-dark']" />
+						<input type="text" :value="optionsStore.theme.customColor" @input="handleCustomColorChange"
+							placeholder="#3a3441" maxlength="7" :class="text.title" />
 					</ul>
 				</div>
 
@@ -165,11 +141,7 @@ function handleClearData() {
 					</template>
 				</RadioGroup>
 
-				<OptionToggle
-					option="time.use24Hour"
-					label="24-hour format"
-					role="menuitem"
-				/>
+				<OptionToggle option="time.use24Hour" label="24-hour format" role="menuitem" />
 
 				<div class="divider" />
 
@@ -179,9 +151,7 @@ function handleClearData() {
 
 				<div class="row">
 					<div :class="text.base">Source:</div>
-					<ExternalLink url="https://openweathermap.org"
-						>OpenWeather</ExternalLink
-					>
+					<ExternalLink url="https://openweathermap.org">OpenWeather</ExternalLink>
 				</div>
 
 				<div class="divider" />
@@ -195,12 +165,7 @@ function handleClearData() {
 					</div>
 					<div v-else :class="text.label">Fetching...</div>
 					<div>
-						<button
-							:class="button.primary"
-							style="margin: 0 auto"
-							:disabled="refreshDisabled"
-							@click="handleFetch()"
-						>
+						<button :class="button.primary" style="margin: 0 auto" :disabled="refreshDisabled" @click="handleFetch()">
 							{{ !refreshDisabled ? 'Refresh' : 'Please wait 15s' }}
 						</button>
 					</div>
@@ -215,11 +180,7 @@ function handleClearData() {
 							}}
 						</div>
 						<div>
-							<button
-								:class="button.primary"
-								style="margin: 0 auto"
-								@click="handleFetch()"
-							>
+							<button :class="button.primary" style="margin: 0 auto" @click="handleFetch()">
 								Enable
 							</button>
 						</div>
@@ -236,16 +197,10 @@ function handleClearData() {
 				<div v-if="optionsStore.init && dataStore.isChromeExtension">
 					<div :class="text.subtitle">Data sync</div>
 
-					<OptionToggle
-						option="useChromeStorage"
-						label="Sync with Chrome"
-						role="menuitem"
-						:onChange="
-							() =>
-								!optionsStore.useChromeStorage &&
-								optionsStore.readChromeStorage()
-						"
-					/>
+					<OptionToggle option="useChromeStorage" label="Sync with Chrome" role="menuitem" :onChange="() =>
+							!optionsStore.useChromeStorage &&
+							optionsStore.readChromeStorage()
+						" />
 					<div :class="text.base">
 						Persist options across your Chrome browsers (overrides your current
 						options). Your location is not synced and will remain on-device.
@@ -267,26 +222,17 @@ function handleClearData() {
 				</div>
 
 				<div class="row even">
-					<ExternalLink
-						url="https://github.com/fvrests/lavender/blob/main/privacy-policy.md"
-						>Privacy Policy
+					<ExternalLink url="https://github.com/fvrests/lavender/blob/main/privacy-policy.md">Privacy Policy
 					</ExternalLink>
-					<ExternalLink
-						url="https://github.com/fvrests/lavender/blob/main/terms-of-use.md"
-						>Terms of Use</ExternalLink
-					>
+					<ExternalLink url="https://github.com/fvrests/lavender/blob/main/terms-of-use.md">Terms of Use</ExternalLink>
 				</div>
 
 				<div class="space-small" />
 
 				<div class="row even">
-					<ExternalLink url="https://fvrests.dev" :underline="true"
-						>fvrests</ExternalLink
-					>
+					<ExternalLink url="https://fvrests.dev" :underline="true">fvrests</ExternalLink>
 
-					<ExternalLink url="https://ko-fi.com/fvrests" :underline="true"
-						>donate ♥</ExternalLink
-					>
+					<ExternalLink url="https://ko-fi.com/fvrests" :underline="true">donate ♥</ExternalLink>
 				</div>
 			</div>
 		</transition>
@@ -306,9 +252,7 @@ function handleClearData() {
 
 .options-menu {
 	--_space-around: var(--page-padding);
-	--_space-around-bottom: calc(
-		var(--_space-around) + 36px + var(--space-small)
-	);
+	--_space-around-bottom: calc(var(--_space-around) + 36px + var(--space-small));
 
 	margin-top: var(--_space-around);
 	color: var(--ui-fg);
@@ -415,7 +359,7 @@ input:focus {
 	grid-template-columns: repeat(6, 1fr);
 }
 
-.theme-list > * {
+.theme-list>* {
 	margin-right: auto;
 	display: inline-flex;
 }

--- a/src/components/theme-select.vue
+++ b/src/components/theme-select.vue
@@ -53,6 +53,7 @@ const props = withDefaults(
 button {
 	height: 30px;
 	width: 30px;
+	aspect-ratio: 1;
 	border-radius: var(--rounded-full);
 	cursor: pointer;
 	border: var(--border);

--- a/src/components/theme-select.vue
+++ b/src/components/theme-select.vue
@@ -10,7 +10,7 @@ const props = withDefaults(
 		split?: boolean
 		dark?: boolean
 	}>(),
-	{ split: false, dark: false }
+	{ split: false, dark: false },
 )
 </script>
 

--- a/src/store/options.ts
+++ b/src/store/options.ts
@@ -1,6 +1,6 @@
 import { defineStore } from 'pinia'
-import { useDataStore } from './data'
 import { isColorDark } from '../utils/helpers'
+import { useDataStore } from './data'
 
 export const useOptionsStore = defineStore('options', {
 	state: () => ({

--- a/src/store/options.ts
+++ b/src/store/options.ts
@@ -1,5 +1,6 @@
 import { defineStore } from 'pinia'
 import { useDataStore } from './data'
+import { isColorDark } from '../utils/helpers'
 
 export const useOptionsStore = defineStore('options', {
 	state: () => ({
@@ -7,6 +8,7 @@ export const useOptionsStore = defineStore('options', {
 		useChromeStorage: false,
 		theme: {
 			color: 'lavender',
+			customColor: '',
 		},
 		time: {
 			layout: 'default',
@@ -31,6 +33,10 @@ export const useOptionsStore = defineStore('options', {
 					(options) => {
 						if (options) {
 							const localOptions = JSON.parse(options)
+							document.documentElement.style.setProperty(
+								'--color-custom',
+								localOptions.theme.customColor,
+							)
 							this.$patch(localOptions)
 						}
 					},
@@ -96,6 +102,13 @@ export const useOptionsStore = defineStore('options', {
 		},
 		setTheme(theme: string) {
 			this.$patch({ theme: { color: theme } })
+			document.documentElement.className = theme
+		},
+		setCustomColor(colorHex: string) {
+			const isDark = isColorDark(colorHex)
+			const theme = isDark ? 'custom-dark' : 'custom'
+			this.$patch({ theme: { customColor: colorHex, color: theme } })
+			document.documentElement.style.setProperty('--color-custom', colorHex)
 			document.documentElement.className = theme
 		},
 		previewTheme(theme: string) {

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -12,3 +12,28 @@ export async function fetchWeather(latitude: number, longitude: number) {
 	)
 	return await res.json()
 }
+
+export function hexToRgb(hex: string) {
+	// Remove the hash at the start if it's there
+	hex = hex.slice(1)
+
+	if (hex.length < 5) {
+		hex = hex.replace(/./g, '$&$&')
+	}
+
+	// Parse r, g, b values
+	const color = +('0x' + hex)
+	const r = color >> 16
+	const g = (color >> 8) & 255
+	const b = color & 255
+
+	return { r, g, b }
+}
+
+// https://awik.io/determine-color-bright-dark-using-javascript/
+export function isColorDark(hex: string) {
+	const { r, g, b } = hexToRgb(hex)
+	// HSP (Highly Sensitive Poo) equation from http://alienryderflex.com/hsp.html
+	const hsp = Math.sqrt(0.299 * (r * r) + 0.587 * (g * g) + 0.114 * (b * b))
+	return hsp < 127.5
+}


### PR DESCRIPTION
Hey @fvrests, 

I've been using Lavender as my new tab page for a while now. I love the Rosé Pine theme colors and changed my themes, including Google Chrome, to match. However, Lavender still works well for me, but they don't really match. I like the minimalist nature of Lavender, so I thought I should contribute a custom color feature to it. The default colors are pretty cool, by the way!

For custom theme, I have added a utility which does the job of deciding whether the color is darker or lighter.

----- Copilot Generated Description -----

This pull request introduces a new custom color theme feature. The most important changes include the addition of a custom color theme, updates to the options menu to support the new theme, and utility functions to handle color processing.

https://github.com/user-attachments/assets/d70d2f4e-4d06-46af-891e-e6e02acf2222

### Custom Color Theme Feature:

* [`src/assets/styles/global.css`](diffhunk://#diff-8e57e24fafbd8da9941d9aee878f522b211c70ca8a5a07d21766dcea0d1421b1R44-R46): Added custom color variables and updated theme classes to include the custom theme.
* [`src/store/options.ts`](diffhunk://#diff-98ea41b4e17019f0d1d6af1076cab56e3ab691fd859d8a3e2b3699cf7ef60c9bR3-R11): Added `customColor` to the theme state and a method to set and preview the custom color.

### Options Menu Updates:

* [`src/components/options.vue`](diffhunk://#diff-3f290800f7cd843bda4d4bee83912235c149b9816a65cfa6e80e8a76207c5f3eR13): Integrated the custom color theme into the options menu, including input handling and theme selection.

### Utility Functions:

* [`src/utils/helpers.ts`](diffhunk://#diff-d9b0865f2e8f841410cd4faf3e1e4a1fb7cb0b545f583f6adaad5841d7eaa58dR15-R39): Added utility functions `hexToRgb` and `isColorDark` to process and determine color brightness.

These changes collectively enable users to customize the theme color and ensure the application handles color selection and theme application effectively.