### PR TITLE
Prevent highlighting time and date

### DIFF
--- a/src/components/clock.vue
+++ b/src/components/clock.vue
@@ -29,6 +29,7 @@ const instanceStore = useInstanceStore()
 .wrapper {
 	grid-area: middle;
 	text-align: center;
+	user-select: none;
 }
 
 .context-label {

--- a/src/components/clock.vue
+++ b/src/components/clock.vue
@@ -30,6 +30,9 @@ const instanceStore = useInstanceStore()
 	grid-area: middle;
 	text-align: center;
 	user-select: none;
+	-webkit-user-select: none; /* Safari */
+	-webkit-touch-callout: none; /* iOS Safari */
+	cursor: default; /* prevents text cursor in Safari */
 }
 
 .context-label {

--- a/src/components/weather.vue
+++ b/src/components/weather.vue
@@ -25,6 +25,10 @@ const dataStore = useDataStore()
 .wrapper {
 	grid-area: bottom;
 	text-align: center;
+	user-select: none;
+	-webkit-user-select: none; /* Safari */
+	-webkit-touch-callout: none; /* iOS Safari */
+	cursor: default; /* prevents text cursor in Safari */
 }
 
 .wi {


### PR DESCRIPTION
I love the minimalism to lavendar, but sometimes when I click on the tab it highlights the date/time which breaks the immersion. Added a small line to prevent that.

Example highlight:
![{27197A62-FF0A-41C8-B3E6-2C9F740576A0}](https://github.com/user-attachments/assets/6978e0f8-69e7-450b-9f2c-95f8adc9f65b)

I think preventing this adds to the minimalist aesthetic of lavendar and that generally people aren't copying date/times from the main screen.